### PR TITLE
fix: wrap role_arn in assume_role due to a breaking change

### DIFF
--- a/terraform-aws-eks-vaultwarden/terragrunt.hcl
+++ b/terraform-aws-eks-vaultwarden/terragrunt.hcl
@@ -7,7 +7,9 @@ remote_state {
 
     config = {
         profile = "terraform@guerzon"
-        role_arn = "arn:aws:iam::<YOUR-AWS-ACCOUNT-ID>:role/TerraformRole"
+        assume_role = {
+          role_arn = "arn:aws:iam::<YOUR-AWS-ACCOUNT-ID>:role/TerraformRole"
+        }
         bucket = "vaultwarden-tf"
         key = "${path_relative_to_include()}/terraform.tfstate"
         region = "ap-southeast-1"


### PR DESCRIPTION
Due to a [breaking change](https://github.com/hashicorp/terraform/pull/35721) introduced inside a minor update and without any form of deprecation warnings whatsoever, `role_arn` inside the backend configuration now needs to be wrapped inside an `assume_role` block.

 https://github.com/hashicorp/terraform/issues/36124